### PR TITLE
Remove dependency on virtual/cargo, which is going away

### DIFF
--- a/eclass/rust-crate.eclass
+++ b/eclass/rust-crate.eclass
@@ -33,10 +33,7 @@ EXPORT_FUNCTIONS src_unpack src_compile src_configure src_install src_test
 SLOT="${PV}/${PR}"
 IUSE="test"
 
-BDEPEND="
-	>=virtual/rust-1.34.1:=
-	>=virtual/cargo-0.32.1
-"
+BDEPEND=">=virtual/rust-1.37.0:="
 
 ECRATE_NAME="${PN}"
 ECARGO_HOME="${WORKDIR}/cargo_home"


### PR DESCRIPTION
Matching the minimum requirements currently in ::gentoo's cargo.eclass
for no reason other than its a reasonable guess for "cargo is guaranteed"

CC @gyakovlev 